### PR TITLE
fix(Client): Readd do not track

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    castle-rb (2.0.1)
+    castle-rb (2.0.2)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/castle-rb/client.rb
+++ b/lib/castle-rb/client.rb
@@ -11,7 +11,7 @@ module Castle
     end
 
     def identify(args)
-      @api.request('identify', args)
+      @api.request('identify', args) unless do_not_track?
     end
 
     def authenticate(args)
@@ -19,8 +19,21 @@ module Castle
     end
 
     def track(args)
-      @api.request('track', args)
+      @api.request('track', args) unless do_not_track?
     end
+
+    def do_not_track!
+      @do_not_track = true
+    end
+
+    def track!
+      @do_not_track = false
+    end
+
+    def do_not_track?
+      !!@do_not_track
+    end
+
 
     private
 


### PR DESCRIPTION
Noticed that the `do_not_track` convenience function is no longer implemented and readded it. (used dor `web` ghoting mode)