### PR TITLE
add possibility to set do not track in constructor options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,17 @@
 - add `require 'castle/support/padrino'` to have Castle client instance available as `castle` in your Padrino helpers
 - add `require 'castle/support/sinatra'` to have Castle client instance available as `castle` in your Sinatra helpers
 - request timeout uses milliseconds unit from now on
+- renamed `track!` to `turn_on_tracking`
+- renamed `do_no_track!` to `turn_off_tracking`
+- renamed `don_no_track?` to `tracked?` with opposite behaviour
+- `Castle::Client` now takes options as a second argument
 
 **Features:**
 
 - [#32](github.com/castle/castle-ruby/pull/32) added helper for generating signature
 - [#27](github.com/castle/castle-ruby/pull/27) added whitelisted and blacklisted to configuration (with defaults)
 - [#41](github.com/castle/castle-ruby/pull/41) added Hanami helpers
+- [#42](github.com/castle/castle-ruby/pull/42) added possibility to set do_not_track flag in `Castle::Client` options
 
 ## 2.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - add `require 'castle/support/padrino'` to have Castle client instance available as `castle` in your Padrino helpers
 - add `require 'castle/support/sinatra'` to have Castle client instance available as `castle` in your Sinatra helpers
 - request timeout uses milliseconds unit from now on
-- renamed `track!` to `turn_on_tracking`
-- renamed `do_no_track!` to `turn_off_tracking`
+- renamed `track!` to `enable_tracking`
+- renamed `do_no_track!` to `disable_tracking`
 - renamed `don_no_track?` to `tracked?` with opposite behaviour
 - `Castle::Client` now takes options as a second argument
 

--- a/lib/castle/client.rb
+++ b/lib/castle/client.rb
@@ -29,11 +29,11 @@ module Castle
       @api.request('track', args) if tracked?
     end
 
-    def turn_off_tracking
+    def disable_tracking
       @do_not_track = true
     end
 
-    def turn_on_tracking
+    def enable_tracking
       @do_not_track = false
     end
 

--- a/lib/castle/support/hanami.rb
+++ b/lib/castle/support/hanami.rb
@@ -4,7 +4,7 @@ module Castle
   module Hanami
     module Action
       def castle
-        @castle ||= ::Castle::Client.new(request, (cookies if defined? cookies))
+        @castle ||= ::Castle::Client.new(request, cookies: (cookies if defined? cookies))
       end
     end
 

--- a/spec/lib/castle/client_spec.rb
+++ b/spec/lib/castle/client_spec.rb
@@ -64,20 +64,13 @@ describe Castle::Client do
 
   describe 'tracked?' do
     context 'off' do
-      before do
-        client.turn_off_tracking
-      end
-      it do
-        expect(client).not_to be_tracked
-      end
+      before { client.disable_tracking }
+      it { expect(client).not_to be_tracked }
     end
+
     context 'on' do
-      before do
-        client.turn_on_tracking
-      end
-      it do
-        expect(client).to be_tracked
-      end
+      before { client.enable_tracking }
+      it { expect(client).to be_tracked }
     end
   end
 end

--- a/spec/lib/castle/client_spec.rb
+++ b/spec/lib/castle/client_spec.rb
@@ -61,4 +61,23 @@ describe Castle::Client do
                      "https://:secret@api.castle.io/v1/reviews/#{review_id}",
                      times: 1
   end
+
+  describe 'tracked?' do
+    context 'off' do
+      before do
+        client.turn_off_tracking
+      end
+      it do
+        expect(client).not_to be_tracked
+      end
+    end
+    context 'on' do
+      before do
+        client.turn_on_tracking
+      end
+      it do
+        expect(client).to be_tracked
+      end
+    end
+  end
 end


### PR DESCRIPTION
We can pass additional options hash as arguments where do_not_track flag, cookies and context can be passed.

Renamed track! because it was a bit confusing. We use track method for something different.