### PR TITLE
symbolize keys for failover strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+**BREAKING CHANGES:**
+
+- [#91](github.com/castle/castle-ruby/pull/91) symbolize keys for failover strategy
+
 ## 3.1.0 (2017-12-11)
 
 **Enhancements:**

--- a/lib/castle/client.rb
+++ b/lib/castle/client.rb
@@ -27,7 +27,7 @@ module Castle
       if tracked?
         command = Castle::Commands::Authenticate.new(@context).build(options)
         begin
-          @api.request(command).merge('failover' => false, 'failover_reason' => nil)
+          @api.request(command).merge(failover: false, failover_reason: nil)
         rescue Castle::RequestError, Castle::InternalServerError => error
           failover_response_or_raise(FailoverAuthResponse.new(options[:user_id], reason: error.to_s), error)
         end

--- a/lib/castle/failover_auth_response.rb
+++ b/lib/castle/failover_auth_response.rb
@@ -11,10 +11,10 @@ module Castle
 
     def generate
       {
-        'action' => @strategy.to_s,
-        'user_id' => @user_id,
-        'failover' => true,
-        'failover_reason' => @reason
+        action: @strategy.to_s,
+        user_id: @user_id,
+        failover: true,
+        failover_reason: @reason
       }
     end
   end

--- a/spec/lib/castle/client_spec.rb
+++ b/spec/lib/castle/client_spec.rb
@@ -104,8 +104,8 @@ describe Castle::Client do
         end
       end
 
-      it { expect(request_response['failover']).to be false }
-      it { expect(request_response['failover_reason']).to be_nil }
+      it { expect(request_response[:failover]).to be false }
+      it { expect(request_response[:failover_reason]).to be_nil }
     end
 
     context 'tracking disabled' do
@@ -115,10 +115,10 @@ describe Castle::Client do
       end
 
       it { assert_not_requested :post, 'https://api.castle.io/v1/authenticate' }
-      it { expect(request_response['action']).to be_eql('allow') }
-      it { expect(request_response['user_id']).to be_eql('1234') }
-      it { expect(request_response['failover']).to be true }
-      it { expect(request_response['failover_reason']).to be_eql('Castle set to do not track.') }
+      it { expect(request_response[:action]).to be_eql('allow') }
+      it { expect(request_response[:user_id]).to be_eql('1234') }
+      it { expect(request_response[:failover]).to be true }
+      it { expect(request_response[:failover_reason]).to be_eql('Castle set to do not track.') }
     end
 
     context 'when request with fail' do
@@ -132,10 +132,10 @@ describe Castle::Client do
 
       context 'with request error and not throw on eg deny strategy' do
         it { assert_not_requested :post, 'https://:secret@api.castle.io/v1/authenticate' }
-        it { expect(request_response['action']).to be_eql('allow') }
-        it { expect(request_response['user_id']).to be_eql('1234') }
-        it { expect(request_response['failover']).to be true }
-        it { expect(request_response['failover_reason']).to be_eql('Castle::RequestError') }
+        it { expect(request_response[:action]).to be_eql('allow') }
+        it { expect(request_response[:user_id]).to be_eql('1234') }
+        it { expect(request_response[:failover]).to be true }
+        it { expect(request_response[:failover_reason]).to be_eql('Castle::RequestError') }
       end
     end
 
@@ -150,10 +150,10 @@ describe Castle::Client do
 
       context 'not throw on eg deny strategy' do
         it { assert_not_requested :post, 'https://:secret@api.castle.io/v1/authenticate' }
-        it { expect(request_response['action']).to be_eql('allow') }
-        it { expect(request_response['user_id']).to be_eql('1234') }
-        it { expect(request_response['failover']).to be true }
-        it { expect(request_response['failover_reason']).to be_eql('Castle::InternalServerError') }
+        it { expect(request_response[:action]).to be_eql('allow') }
+        it { expect(request_response[:user_id]).to be_eql('1234') }
+        it { expect(request_response[:failover]).to be true }
+        it { expect(request_response[:failover_reason]).to be_eql('Castle::InternalServerError') }
       end
     end
   end


### PR DESCRIPTION
noticed this during local dev. @nijikon @wallin It should become `4.0.0` since they are breaking changes. Thoughts?