### PR TITLE
support ruby >= 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## master
 
+**BREAKING CHANGES:**
+
+- [#165](https://github.com/castle/castle-ruby/pull/165) support ruby >= 2.4
+
 **Enhancements:**
 
-- (https://github.com/castle/castle-ruby/pull/163) scrub headers instead of dropping them
+- [#163](https://github.com/castle/castle-ruby/pull/163) scrub headers instead of dropping them
 
 
 ## 3.5.2 (2019-01-09)

--- a/castle-rb.gemspec
+++ b/castle-rb.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.test_files  = Dir['spec/**/*']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.2.6'
+  s.required_ruby_version = '>= 2.4'
 end


### PR DESCRIPTION
We are not testing against rubies older than 2.4 hence we won't support it anymore. Ruby `2.4` is supported until the end of March of 2020.