### PR TITLE
release v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+## 3.6.0 (2020-01-07)
+
 **BREAKING CHANGES:**
 
 - [#165](https://github.com/castle/castle-ruby/pull/165) support ruby >= 2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    castle-rb (3.5.2)
+    castle-rb (3.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/castle/version.rb
+++ b/lib/castle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Castle
-  VERSION = '3.5.2'
+  VERSION = '3.6.0'
 end


### PR DESCRIPTION
- drop support for `ruby < 2.4`
- scrub headers instead of dropping them