### PR TITLE
Drop special handling for CF IP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [#171](https://github.com/castle/castle-ruby/pull/171) test against Rails 5 and Rails 6
 
+**Bug fixes**:
+
+- [#175](https://github.com/castle/castle-ruby/pull/175) drop special handling of cf ip header
+
 ## 3.6.1 (2020-01-16)
 
 **Bug fixes**:

--- a/lib/castle/extractors/ip.rb
+++ b/lib/castle/extractors/ip.rb
@@ -9,7 +9,6 @@ module Castle
       end
 
       def call
-        return @request.env['HTTP_CF_CONNECTING_IP'] if @request.env['HTTP_CF_CONNECTING_IP']
         return @request.remote_ip if @request.respond_to?(:remote_ip)
         @request.ip
       end

--- a/spec/lib/castle/extractors/ip_spec.rb
+++ b/spec/lib/castle/extractors/ip_spec.rb
@@ -7,10 +7,13 @@ describe Castle::Extractors::IP do
 
   describe 'ip' do
     context 'when regular ip' do
-      let(:env) {
-        Rack::MockRequest.env_for('/',
-          'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 1.2.2.2, 1.2.3.5')
-      }
+      let(:env) do
+        Rack::MockRequest.env_for(
+          '/',
+          'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 1.2.2.2, 1.2.3.5'
+        )
+      end
+
 
       it { expect(extractor.call).to eql('1.2.3.5') }
     end

--- a/spec/lib/castle/extractors/ip_spec.rb
+++ b/spec/lib/castle/extractors/ip_spec.rb
@@ -7,7 +7,10 @@ describe Castle::Extractors::IP do
 
   describe 'ip' do
     context 'when regular ip' do
-      let(:env) { Rack::MockRequest.env_for('/', 'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 1.2.2.2, 1.2.3.5') }
+      let(:env) {
+        Rack::MockRequest.env_for('/',
+          'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 1.2.2.2, 1.2.3.5')
+      }
 
       it { expect(extractor.call).to eql('1.2.3.5') }
     end

--- a/spec/lib/castle/extractors/ip_spec.rb
+++ b/spec/lib/castle/extractors/ip_spec.rb
@@ -7,21 +7,9 @@ describe Castle::Extractors::IP do
 
   describe 'ip' do
     context 'when regular ip' do
-      let(:env) { Rack::MockRequest.env_for('/', 'HTTP_X_FORWARDED_FOR' => '1.2.3.5') }
+      let(:env) { Rack::MockRequest.env_for('/', 'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 1.2.2.2, 1.2.3.5') }
 
       it { expect(extractor.call).to eql('1.2.3.5') }
-    end
-
-    context 'when cf remote_ip' do
-      let(:env) do
-        Rack::MockRequest.env_for(
-          '/',
-          'HTTP_CF_CONNECTING_IP' => '1.2.3.4',
-          'HTTP_X_FORWARDED_FOR' => '1.2.3.5'
-        )
-      end
-
-      it { expect(extractor.call).to eql('1.2.3.4') }
     end
   end
 end


### PR DESCRIPTION
This should be handled separately and we'll add an update to make it easier to get IP from headers