### PR TITLE
don't append default headers to ip_headers, drop X-Client-Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- dropped X-Client-Id from calculation of ip, drop appending default ip headers to the ip_header list config when config is provided (in that case default headers have to explicitly provided)
+- [#187](https://github.com/castle/castle-ruby/pull/187) dropped X-Client-Id from calculation of ip, drop appending default ip headers to the ip_header list config when config is provided (in that case default headers have to explicitly provided)
 
 
 ## 4.1.0 (2020-03-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+- dropped X-Client-Id from calculation of ip, drop appending default ip headers to the ip_header list config when config is provided (in that case default headers have to explicitly provided)
+
+
 ## 4.1.0 (2020-03-27)
 
 - [#184](https://github.com/castle/castle-ruby/pull/184) added Castle::API::Session which exposes Net:Http instance for reuse

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Castle.configure do |config|
   config.blacklisted = ['HTTP-X-header']
 
   # Castle needs the original IP of the client, not the IP of your proxy or load balancer.
-  # we try to fetch proper ip based on X-Forwarded-For, X-Client-Id or Remote-Addr headers in that order
+  # we try to fetch proper ip based on X-Forwarded-For or Remote-Addr headers in that order
   # but sometimes proper ip may be stored in different header or order could be different.
   # SDK can extract ip automatically for you, but you must configure which ip_headers you would like to use
   configuration.ip_headers = []
 
-  # Additionally to make X-Forwarded-For or X-Client-Id work better discovering client ip address,
+  # Additionally to make X-Forwarded-For and other headers work better discovering client ip address,
   # and not the address of a reverse proxy server, you can define trusted proxies
   # which will help to fetch proper ip from those headers
   configuration.trusted_proxies = []

--- a/lib/castle/extractors/ip.rb
+++ b/lib/castle/extractors/ip.rb
@@ -5,42 +5,38 @@ module Castle
     # used for extraction of ip from the request
     class IP
       # ordered list of ip headers for ip extraction
-      DEFAULT = %w[X-Forwarded-For Client-Ip Remote-Addr].freeze
-      # default header fallback when ip is not found
-      FALLBACK = 'Remote-Addr'
+      DEFAULT = %w[X-Forwarded-For Remote-Addr].freeze
 
-      private_constant :FALLBACK, :DEFAULT
+      private_constant :DEFAULT
 
       # @param headers [Hash]
       def initialize(headers)
         @headers = headers
-        @ip_headers = Castle.config.ip_headers + DEFAULT
+        @ip_headers = Castle.config.ip_headers.empty? ? DEFAULT : Castle.config.ip_headers
         @proxies = Castle.config.trusted_proxies + Castle::Configuration::TRUSTED_PROXIES
       end
 
       # Order of headers:
       #   .... list of headers defined by ip_headers
       #   X-Forwarded-For
-      #   Client-Ip is
       #   Remote-Addr
       # @return [String]
       def call
+        all_ips = []
+
         @ip_headers.each do |ip_header|
-          ip_value = calculate_ip(ip_header)
+          ips = ips_from(ip_header)
+          ip_value = remove_proxies(ips).last
           return ip_value if ip_value
+
+          all_ips.push(*ips)
         end
 
-        @headers[FALLBACK]
+        # fallback to first whatever ip
+        all_ips.first
       end
 
       private
-
-      # @param header [String]
-      # @return [String]
-      def calculate_ip(header)
-        ips = ips_from(header)
-        remove_proxies(ips).first
-      end
 
       # @param ips [Array<String>]
       # @return [Array<String>]
@@ -61,7 +57,7 @@ module Castle
 
         return [] unless value
 
-        value.strip.split(/[,\s]+/).reverse
+        value.strip.split(/[,\s]+/)
       end
     end
   end

--- a/spec/lib/castle/extractors/ip_spec.rb
+++ b/spec/lib/castle/extractors/ip_spec.rb
@@ -21,20 +21,20 @@ describe Castle::Extractors::IP do
       end
 
       context 'with uppercase format' do
-        before { Castle.config.ip_headers = %w[CF_CONNECTING_IP] }
+        before { Castle.config.ip_headers = %w[CF_CONNECTING_IP X-Forwarded-For] }
 
         it { expect(extractor.call).to eql('1.2.3.4') }
       end
 
       context 'with regular format' do
-        before { Castle.config.ip_headers = %w[Cf-Connecting-Ip] }
+        before { Castle.config.ip_headers = %w[Cf-Connecting-Ip X-Forwarded-For] }
 
         it { expect(extractor.call).to eql('1.2.3.4') }
       end
 
-      context 'with value from trusted proxies' do
+      context 'with value from trusted proxies it get seconds header' do
         before do
-          Castle.config.ip_headers = %w[Cf-Connecting-Ip]
+          Castle.config.ip_headers = %w[Cf-Connecting-Ip X-Forwarded-For]
           Castle.config.trusted_proxies = %w[1.2.3.4]
         end
 
@@ -49,7 +49,7 @@ describe Castle::Extractors::IP do
 
       let(:headers) { { 'Remote-Addr' => '127.0.0.1', 'X-Forwarded-For' => http_x_header } }
 
-      it 'fallbacks to remote_addr even if trusted proxy' do
+      it 'fallbacks to first available header when all headers are marked trusted proxy' do
         expect(extractor.call).to eql('127.0.0.1')
       end
     end


### PR DESCRIPTION
- also  when all marked as trusted proxy  - dropped fallback to  Remote-Addr  instead used first whatever value provided