### PR TITLE
adding support for risk and filter failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+## 7.1.1 
+
+- [#246](https://github.com/castle/castle-ruby/pull/246)
+  * support failover for risk and filter
+
 ## 7.1.0 (2021-06-09)
 
 - [#245](https://github.com/castle/castle-ruby/pull/245) 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    castle-rb (7.1.0)
+    castle-rb (7.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -104,4 +104,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.19

--- a/lib/castle/failover/prepare_response.rb
+++ b/lib/castle/failover/prepare_response.rb
@@ -11,7 +11,17 @@ module Castle
       end
 
       def call
-        { action: @strategy.to_s, user_id: @user_id, failover: true, failover_reason: @reason }
+        {
+          # v1/risk v1/filter structure
+          policy: {
+            action: @strategy.to_s,
+          },
+          # v1/authenticate structure
+          action: @strategy.to_s,
+          user_id: @user_id,
+          failover: true,
+          failover_reason: @reason
+        }
       end
     end
   end

--- a/lib/castle/failover/prepare_response.rb
+++ b/lib/castle/failover/prepare_response.rb
@@ -14,7 +14,7 @@ module Castle
         {
           # v1/risk v1/filter structure
           policy: {
-            action: @strategy.to_s,
+            action: @strategy.to_s
           },
           # v1/authenticate structure
           action: @strategy.to_s,

--- a/lib/castle/version.rb
+++ b/lib/castle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Castle
-  VERSION = '7.1.0'
+  VERSION = '7.1.1'
 end

--- a/spec/lib/castle/client_spec.rb
+++ b/spec/lib/castle/client_spec.rb
@@ -225,6 +225,7 @@ describe Castle::Client do
       end
 
       it { assert_not_requested :post, 'https://api.castle.io/v1/authenticate' }
+      it { expect(request_response[:policy][:action]).to be_eql(Castle::Verdict::ALLOW) }
       it { expect(request_response[:action]).to be_eql(Castle::Verdict::ALLOW) }
       it { expect(request_response[:user_id]).to be_eql('1234') }
       it { expect(request_response[:failover]).to be true }
@@ -246,6 +247,7 @@ describe Castle::Client do
 
       context 'with request error and not throw on eg deny strategy' do
         it { assert_not_requested :post, 'https://:secret@api.castle.io/v1/authenticate' }
+        it { expect(request_response[:policy][:action]).to be_eql('allow') }
         it { expect(request_response[:action]).to be_eql('allow') }
         it { expect(request_response[:user_id]).to be_eql('1234') }
         it { expect(request_response[:failover]).to be true }
@@ -266,6 +268,7 @@ describe Castle::Client do
 
       describe 'not throw on eg deny strategy' do
         it { assert_not_requested :post, 'https://:secret@api.castle.io/v1/authenticate' }
+        it { expect(request_response[:policy][:action]).to be_eql('allow') }
         it { expect(request_response[:action]).to be_eql('allow') }
         it { expect(request_response[:user_id]).to be_eql('1234') }
         it { expect(request_response[:failover]).to be true }

--- a/spec/support/shared_examples/action_request.rb
+++ b/spec/support/shared_examples/action_request.rb
@@ -104,6 +104,7 @@ RSpec.shared_examples_for 'action request' do |action|
     end
 
     it { assert_not_requested :post, "https://api.castle.io/v1/#{action}" }
+    it { expect(request_response[:policy][:action]).to be_eql(Castle::Verdict::ALLOW) }
     it { expect(request_response[:action]).to be_eql(Castle::Verdict::ALLOW) }
     it { expect(request_response[:user_id]).to be_eql('1234') }
     it { expect(request_response[:failover]).to be true }
@@ -125,6 +126,7 @@ RSpec.shared_examples_for 'action request' do |action|
 
     context 'with request error and not throw on eg deny strategy' do
       it { assert_not_requested :post, "https:/:secret@api.castle.io/v1/#{action}" }
+      it { expect(request_response[:policy][:action]).to be_eql('allow') }
       it { expect(request_response[:action]).to be_eql('allow') }
       it { expect(request_response[:user_id]).to be_eql('1234') }
       it { expect(request_response[:failover]).to be true }
@@ -143,6 +145,7 @@ RSpec.shared_examples_for 'action request' do |action|
 
     describe 'not throw on eg deny strategy' do
       it { assert_not_requested :post, "https:/:secret@api.castle.io/v1/#{action}" }
+      it { expect(request_response[:policy][:action]).to be_eql('allow') }
       it { expect(request_response[:action]).to be_eql('allow') }
       it { expect(request_response[:user_id]).to be_eql('1234') }
       it { expect(request_response[:failover]).to be true }


### PR DESCRIPTION
the structure of authenticate differs from risk and filter

authenticate - { action: 'allow|deny|challenge' }
risk/filter - { policy: { action: 'allow|deny|challenge' } }