### PR TITLE
CVE-2024-43398: Bump rexml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,7 @@ GEM
     public_suffix (6.0.1)
     rack (3.1.7)
     rake (13.2.1)
-    rexml (3.3.4)
-      strscan
+    rexml (3.3.8)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -49,7 +48,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    strscan (3.1.0)
     sync (0.5.0)
     term-ansicolor (1.11.2)
       tins (~> 1.0)


### PR DESCRIPTION
Fix CVE-2024-43398 in rexml
